### PR TITLE
Use HTTPoison error messaging in MISP.HTTP.handle_response/1

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -12,9 +12,10 @@ defmodule MISP.HTTP do
   end
 
   defp defaults(), do: [timeout: 100 * 60]
-  defp client_options(options), do: Keyword.get(options, :client_options, [])
+  defp client_options(options), do: Keyword.get(options, :client_config, [])
 
-  defp client_config(options), do: Keyword.merge(defaults(), client_options(options))
+  defp client_config(options),
+    do: Keyword.merge(defaults(), client_options(options))
 
   @doc """
   An HTTP GET Request

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -12,7 +12,7 @@ defmodule MISP.HTTP do
   end
 
   defp defaults(), do: [timeout: 100 * 60]
-  defp client_options(options), do: Keyword.get(options, :client_options)
+  defp client_options(options), do: Keyword.get(options, :client_options, [])
 
   defp client_config(options), do: Keyword.merge(defaults(), client_options(options))
 

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -11,6 +11,11 @@ defmodule MISP.HTTP do
     ]
   end
 
+  defp defaults(), do: [timeout: 100 * 60]
+  defp client_options(options), do: Keyword.get(options, :client_options)
+
+  defp client_config(options), do: Keyword.merge(defaults(), client_options(options))
+
   @doc """
   An HTTP GET Request
 
@@ -26,7 +31,7 @@ defmodule MISP.HTTP do
     |> URI.to_string()
     |> HTTPoison.get(
       headers(options),
-      timeout: 100 * 60
+      client_config(options)
     )
     |> handle_response()
     |> decode_response(decode_as)
@@ -48,7 +53,7 @@ defmodule MISP.HTTP do
     |> HTTPoison.post(
       Poison.encode!(body),
       headers(options),
-      timeout: 100 * 60
+      client_config(options)
     )
     |> handle_response()
     |> decode_response(decode_as)
@@ -69,7 +74,7 @@ defmodule MISP.HTTP do
     |> URI.to_string()
     |> HTTPoison.delete(
       headers(options),
-      timeout: 100 * 60
+      client_config(options)
     )
     |> handle_response()
     |> decode_response(nil)

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -83,8 +83,8 @@ defmodule MISP.HTTP do
       {:ok, %HTTPoison.Response{status_code: _, body: body}} ->
         {:error, body}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, "HTTP Error #{reason}"}
+      {:error, %HTTPoison.Error{} = e} ->
+        {:error, "HTTP Error #{HTTPoison.Error.message(e)}"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule MISP.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:typed_struct, "~> 0.1.4"},
       {:accessible, "~> 0.2.1"},
-      {:jason, "~> 1.1.2"}
+      {:jason, "~> 1.2"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,17 +24,17 @@ defmodule MISP.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :httpoison]
+      extra_applications: [:logger, :eex, :httpoison]
     ]
   end
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:httpoison, "~> 1.4"},
-      {:poison, "~> 3.1"},
+      {:httpoison, "~> 1.8"},
+      {:poison, "~> 4.0.1"},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:typed_struct, "~> 0.1.4"},
+      {:typed_struct, "~> 0.2.1"},
       {:accessible, "~> 0.2.1"},
       {:jason, "~> 1.2"}
     ]


### PR DESCRIPTION
Uses `HTTPoison.Error.message/1` to better handle errors.

Resolves #1 